### PR TITLE
Feat/lp 25 implement level selection

### DIFF
--- a/src/app/lingua-puzzle/components/card-list/card-list.component.html
+++ b/src/app/lingua-puzzle/components/card-list/card-list.component.html
@@ -3,7 +3,7 @@
 @let resultHeight = cardHeight * numberOfSentences + 'px';
 
 @if (listType() === 'result') {
-  @for (card of cardList(); track card) {
+  @for (card of cardList(); track card.originalIndex) {
     <mat-card
       appWordCard
       class="word"
@@ -22,7 +22,7 @@
 }
 
 @if (listType() === 'source') {
-  @for (card of cardList(); track card) {
+  @for (card of cardList(); track card.originalIndex) {
     <mat-card
       appWordCard
       class="word"
@@ -39,7 +39,7 @@
 }
 
 @if (listType() === 'completed') {
-  @for (card of cardList(); track card) {
+  @for (card of cardList(); track card.originalIndex) {
     <div
       class="word"
       [class.first-word]="$index === 0"

--- a/src/app/lingua-puzzle/components/card-list/card-list.component.scss
+++ b/src/app/lingua-puzzle/components/card-list/card-list.component.scss
@@ -1,10 +1,11 @@
 :host {
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
   height: 35px;
 
   &.completed {
+    justify-content: space-between;
+
     &.first-sentence {
       .first-word {
         border-top-left-radius: 8px;

--- a/src/app/lingua-puzzle/components/game/game.component.html
+++ b/src/app/lingua-puzzle/components/game/game.component.html
@@ -1,3 +1,5 @@
+<app-levels />
+
 <div>
   <mat-checkbox [(ngModel)]="hintsSetting.translation">enable translation</mat-checkbox>
   <mat-checkbox [(ngModel)]="hintsSetting.audio">enable audio</mat-checkbox>

--- a/src/app/lingua-puzzle/components/game/game.component.ts
+++ b/src/app/lingua-puzzle/components/game/game.component.ts
@@ -6,6 +6,7 @@ import { PuzzleService } from '../../services/puzzle/puzzle.service';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { FormsModule } from '@angular/forms';
 import { LocalStorageService } from '../../../core/storage/services/local-storage/local-storage.service';
+import { LevelsComponent } from '../levels/levels.component';
 
 interface hintsSettingStorage {
   translation: boolean;
@@ -16,7 +17,7 @@ interface hintsSettingStorage {
 @Component({
   selector: 'app-game',
   standalone: true,
-  imports: [MatButton, HintsComponent, PuzzleComponent, MatCheckbox, FormsModule],
+  imports: [MatButton, HintsComponent, PuzzleComponent, MatCheckbox, FormsModule, LevelsComponent],
   templateUrl: './game.component.html',
   styleUrl: './game.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/lingua-puzzle/components/levels/levels.component.html
+++ b/src/app/lingua-puzzle/components/levels/levels.component.html
@@ -1,6 +1,6 @@
 <mat-form-field>
   <mat-label>Level</mat-label>
-  <mat-select [(value)]="levelIndex">
+  <mat-select [(value)]="levelIndex" (valueChange)="changeLevel()">
     @for (level of levels; track $index) {
       <mat-option [value]="level">{{ level }}</mat-option>
     }

--- a/src/app/lingua-puzzle/components/levels/levels.component.html
+++ b/src/app/lingua-puzzle/components/levels/levels.component.html
@@ -10,7 +10,7 @@
 @if (rounds.length > 1) {
   <mat-form-field>
     <mat-label>Round</mat-label>
-    <mat-select [(value)]="roundIndex">
+    <mat-select [(value)]="roundIndex" (valueChange)="changeRound()">
       @for (round of rounds; track $index) {
         <mat-option [value]="$index">{{ $index + 1 }}</mat-option>
       }

--- a/src/app/lingua-puzzle/components/levels/levels.component.html
+++ b/src/app/lingua-puzzle/components/levels/levels.component.html
@@ -1,0 +1,8 @@
+<mat-form-field>
+  <mat-label>Level</mat-label>
+  <mat-select [(value)]="currentLevel">
+    @for (level of levels; track $index) {
+      <mat-option [value]="level">{{ level }}</mat-option>
+    }
+  </mat-select>
+</mat-form-field>

--- a/src/app/lingua-puzzle/components/levels/levels.component.html
+++ b/src/app/lingua-puzzle/components/levels/levels.component.html
@@ -1,8 +1,19 @@
 <mat-form-field>
   <mat-label>Level</mat-label>
-  <mat-select [(value)]="currentLevel">
+  <mat-select [(value)]="levelIndex">
     @for (level of levels; track $index) {
       <mat-option [value]="level">{{ level }}</mat-option>
     }
   </mat-select>
 </mat-form-field>
+
+@if (rounds.length > 1) {
+  <mat-form-field>
+    <mat-label>Round</mat-label>
+    <mat-select [(value)]="roundIndex">
+      @for (round of rounds; track $index) {
+        <mat-option [value]="$index">{{ $index + 1 }}</mat-option>
+      }
+    </mat-select>
+  </mat-form-field>
+}

--- a/src/app/lingua-puzzle/components/levels/levels.component.spec.ts
+++ b/src/app/lingua-puzzle/components/levels/levels.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LevelsComponent } from './levels.component';
+
+describe('LevelsComponent', () => {
+  let component: LevelsComponent;
+  let fixture: ComponentFixture<LevelsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LevelsComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(LevelsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/lingua-puzzle/components/levels/levels.component.ts
+++ b/src/app/lingua-puzzle/components/levels/levels.component.ts
@@ -1,0 +1,24 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import {
+  MatFormField,
+  MatLabel,
+  MatOption,
+  MatSelect,
+  MatSelectTrigger,
+} from '@angular/material/select';
+import { FormsModule } from '@angular/forms';
+import { LevelService } from '../../services/level/level.service';
+
+@Component({
+  selector: 'app-levels',
+  standalone: true,
+  imports: [MatSelect, FormsModule, MatFormField, MatSelectTrigger, MatOption, MatLabel],
+  templateUrl: './levels.component.html',
+  styleUrl: './levels.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LevelsComponent {
+  private readonly levelService = inject(LevelService);
+  protected levels = this.levelService.levels;
+  protected currentLevel = this.levelService.currentLevel;
+}

--- a/src/app/lingua-puzzle/components/levels/levels.component.ts
+++ b/src/app/lingua-puzzle/components/levels/levels.component.ts
@@ -37,6 +37,12 @@ export class LevelsComponent {
     });
   }
 
+  public changeLevel(): void {
+    this.levelService.setLevel(this.levelIndex());
+    this.roundIndex = 0;
+    this.changeRound();
+  }
+
   protected changeRound(): void {
     this.roundService.setRound(this.roundIndex);
   }

--- a/src/app/lingua-puzzle/components/levels/levels.component.ts
+++ b/src/app/lingua-puzzle/components/levels/levels.component.ts
@@ -36,4 +36,8 @@ export class LevelsComponent {
       this.cdr.detectChanges();
     });
   }
+
+  protected changeRound(): void {
+    this.roundService.setRound(this.roundIndex);
+  }
 }

--- a/src/app/lingua-puzzle/components/levels/levels.component.ts
+++ b/src/app/lingua-puzzle/components/levels/levels.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject } from '@angular/core';
 import {
   MatFormField,
   MatLabel,
@@ -8,6 +8,7 @@ import {
 } from '@angular/material/select';
 import { FormsModule } from '@angular/forms';
 import { LevelService } from '../../services/level/level.service';
+import { RoundService } from '../../services/round/round.service';
 
 @Component({
   selector: 'app-levels',
@@ -20,5 +21,19 @@ import { LevelService } from '../../services/level/level.service';
 export class LevelsComponent {
   private readonly levelService = inject(LevelService);
   protected levels = this.levelService.levels;
-  protected currentLevel = this.levelService.currentLevel;
+  protected levelIndex = this.levelService.currentLevel;
+
+  private readonly roundService = inject(RoundService);
+  protected rounds = this.roundService.rounds;
+  protected roundIndex = this.roundService.roundIndex;
+
+  private readonly cdr = inject(ChangeDetectorRef);
+
+  constructor() {
+    this.roundService.round.subscribe(() => {
+      this.roundIndex = this.roundService.roundIndex;
+      this.rounds = this.roundService.rounds;
+      this.cdr.detectChanges();
+    });
+  }
 }

--- a/src/app/lingua-puzzle/services/level/level.service.ts
+++ b/src/app/lingua-puzzle/services/level/level.service.ts
@@ -4,10 +4,10 @@ import { Injectable } from '@angular/core';
   providedIn: 'root',
 })
 export class LevelService {
+  public levels = [1, 2, 3, 4, 5, 6];
   public currentLevel = 1;
 
   public get levelUrl(): string {
     return `project-data/data/wordCollectionLevel${String(this.currentLevel)}.json`;
   }
 }
-

--- a/src/app/lingua-puzzle/services/level/level.service.ts
+++ b/src/app/lingua-puzzle/services/level/level.service.ts
@@ -1,13 +1,18 @@
-import { Injectable } from '@angular/core';
+import { Injectable, signal } from '@angular/core';
 
 @Injectable({
   providedIn: 'root',
 })
 export class LevelService {
   public levels = [1, 2, 3, 4, 5, 6];
-  public currentLevel = 1;
+
+  public currentLevel = signal(1);
+
+  public setLevel(levelIndex: number): void {
+    this.currentLevel.set(levelIndex);
+  }
 
   public get levelUrl(): string {
-    return `project-data/data/wordCollectionLevel${String(this.currentLevel)}.json`;
+    return `project-data/data/wordCollectionLevel${String(this.currentLevel())}.json`;
   }
 }

--- a/src/app/lingua-puzzle/services/round/round.service.ts
+++ b/src/app/lingua-puzzle/services/round/round.service.ts
@@ -1,22 +1,27 @@
-import { inject, Injectable } from '@angular/core';
+import { effect, inject, Injectable } from '@angular/core';
 import { Round } from '../../../shared/types/http-data.interface';
 import { HttpDataService } from '../../../core/services/http-data.service';
 import { Subject } from 'rxjs';
+import { LevelService } from '../level/level.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class RoundService {
   private readonly httpData = inject(HttpDataService);
+  private readonly levelService = inject(LevelService);
 
   public rounds: Round[] = [];
   public round = new Subject<Round>();
   public roundIndex = 0;
 
   constructor() {
-    this.httpData.getRounds().subscribe((rounds) => {
-      this.rounds = rounds;
-      this.setRound(0);
+    effect(() => {
+      this.levelService.currentLevel();
+      this.httpData.getRounds().subscribe((rounds) => {
+        this.rounds = rounds;
+        this.setRound(0);
+      });
     });
   }
 

--- a/src/app/lingua-puzzle/services/round/round.service.ts
+++ b/src/app/lingua-puzzle/services/round/round.service.ts
@@ -16,18 +16,17 @@ export class RoundService {
   constructor() {
     this.httpData.getRounds().subscribe((rounds) => {
       this.rounds = rounds;
-      this.roundIndex = 0;
-      this.setRound();
+      this.setRound(0);
     });
   }
 
-  private setRound(): void {
-    this.round.next(this.rounds[this.roundIndex]);
+  public setRound(roundIndex: number): void {
+    this.roundIndex = roundIndex;
+    this.round.next(this.rounds[roundIndex]);
   }
   public nextRound(): void {
     if (this.roundIndex < this.rounds.length - 1) {
-      this.roundIndex += 1;
-      this.setRound();
+      this.setRound(this.roundIndex + 1);
     }
   }
 }


### PR DESCRIPTION
## Overview
implement level and round selection
## Features Implemented
- card lists are now tracked by card's originalIndex
- implement dropdown selection for level and round
- rounds are listed in base of the current level
- game is updated on level/round change